### PR TITLE
New "show_artifact_location_hints" config

### DIFF
--- a/src/bin/randomprime_patcher.rs
+++ b/src/bin/randomprime_patcher.rs
@@ -243,6 +243,13 @@ fn interactive() -> Result<patches::ParsedConfig, String>
         &match_bool
     )?;
 
+    let show_artifact_location_hints = read_option(
+        "Show Chozo Artifact locations at Artifact Temple?", prefs.get("show_artifact_location_hints").map(|x| x.as_str()).unwrap_or("No"),
+        concat!("\nIf yes, you will be able to find out where Chozo Artifacts are located",
+                "\nvia the totem scans in the Artifact Temple."),
+        &match_bool
+    )?;
+
 
     /* let keep_fmvs = read_option(
         "Remove attract mode?", "Yes", "If yes, the attract mode FMVs are remov",
@@ -294,6 +301,7 @@ fn interactive() -> Result<patches::ParsedConfig, String>
         staggered_suit_damage,
         keep_fmvs: false,
         obfuscate_items,
+        show_artifact_location_hints,
         quiet: false,
 
         starting_items: None,
@@ -347,6 +355,9 @@ fn get_config() -> Result<patches::ParsedConfig, String>
             .arg(Arg::with_name("obfuscate items")
                 .long("obfuscate-items")
                 .help("Replace all item models with an obfuscated one"))
+            .arg(Arg::with_name("show artifact location hints")
+                .long("show-artifact-hint-locations")
+                .help("Allow Chozo Artifact location hints via Artifact Temple totem scans"))
             .arg(Arg::with_name("quiet")
                 .long("quiet")
                 .help("Don't print the progress messages"))
@@ -398,6 +409,7 @@ fn get_config() -> Result<patches::ParsedConfig, String>
             staggered_suit_damage: matches.is_present("staggered suit damage"),
             keep_fmvs: matches.is_present("keep attract mode"),
             obfuscate_items: matches.is_present("obfuscate items"),
+            show_artifact_location_hints: matches.is_present("show artifact location hints"),
             quiet: matches.is_present("quiet"),
 
             // XXX We can unwrap safely because we verified the parse earlier

--- a/src/bin/randomprime_patcher.rs
+++ b/src/bin/randomprime_patcher.rs
@@ -356,7 +356,7 @@ fn get_config() -> Result<patches::ParsedConfig, String>
                 .long("obfuscate-items")
                 .help("Replace all item models with an obfuscated one"))
             .arg(Arg::with_name("show artifact location hints")
-                .long("show-artifact-hint-locations")
+                .long("show-artifact-location-hints")
                 .help("Allow Chozo Artifact location hints via Artifact Temple totem scans"))
             .arg(Arg::with_name("quiet")
                 .long("quiet")

--- a/src/c_interface.rs
+++ b/src/c_interface.rs
@@ -43,6 +43,8 @@ struct Config
     staggered_suit_damage: bool,
     #[serde(default)]
     obfuscate_items: bool,
+    #[serde(default)]
+    show_artifact_location_hints: bool,
 
     #[serde(default)]
     keep_fmvs: bool,
@@ -190,6 +192,7 @@ fn inner(config_json: *const c_char, cb_data: *const (), cb: extern fn(*const ()
         staggered_suit_damage: config.staggered_suit_damage,
         keep_fmvs: config.keep_fmvs,
         obfuscate_items: config.obfuscate_items,
+        show_artifact_location_hints: config.show_artifact_location_hints,
         quiet: false,
 
         starting_items: config.starting_items,

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -249,7 +249,7 @@ fn add_skip_hudmemos_strgs(pickup_resources: &mut HashMap<(u32, FourCC), structs
     }
 }
 
-fn build_artifact_temple_totem_scan_strings<R>(pickup_layout: &[u8], rng: &mut R, showHints: bool)
+fn build_artifact_temple_totem_scan_strings<R>(pickup_layout: &[u8], rng: &mut R, show_hints: bool)
     -> [String; 12]
     where R: Rng + Rand
 {
@@ -309,7 +309,7 @@ fn build_artifact_temple_totem_scan_strings<R>(pickup_layout: &[u8], rng: &mut R
         }
 
         // If artifact hints are allowed, proceed with spoiler message handling. Else, use a default, non-spoiler string.
-        if showHints {
+        if show_hints {
             // If there are specific messages for this room, choose one, other wise choose a generic
             // message.
             let template = specific_room_templates.iter_mut()


### PR DESCRIPTION
If disabled, a non-spoiler string is used for the totem scan entry. Admittedly there are CPU cycles being wasted on randomizing the hint string array, but this is a start.