### PR TITLE
Fixed Starting Location and Starting Items

### DIFF
--- a/src/bin/randomprime_patcher.rs
+++ b/src/bin/randomprime_patcher.rs
@@ -193,9 +193,9 @@ fn get_config() -> Result<patches::ParsedConfig, String>
     let (pickup_layout, elevator_nums, seed) = parse_layout(&layout_string)?;
     let skip_impact_crater = matches.is_present("skip impact crater");
 
-    let starting_location = SpawnRoom::from_u32(elevator_nums[0] as u32).unwrap();
+    let starting_location = SpawnRoom::from_u32(*elevator_nums.last().unwrap() as u32).unwrap();
     let mut elevator_layout = EnumMap::<Elevator, SpawnRoom>::new();
-    elevator_layout.extend(elevator_nums[1..].iter()
+    elevator_layout.extend(elevator_nums[..(elevator_nums.len() - 1)].iter()
         .zip(Elevator::iter())
         .map(|(i, elv)| (elv, SpawnRoom::from_u32(*i as u32).unwrap()))
     );
@@ -214,6 +214,10 @@ fn get_config() -> Result<patches::ParsedConfig, String>
     } else {
         None
     };
+
+    let random_starting_items = matches.value_of("random starting items")
+        .map(|s| StartingItems::from_u64(s.parse().unwrap()))
+        .unwrap_or(StartingItems::from_u64(0));
 
     Ok(patches::ParsedConfig {
         input_iso: input_iso_mmap,
@@ -246,9 +250,7 @@ fn get_config() -> Result<patches::ParsedConfig, String>
         starting_items: matches.value_of("change starting items")
                                 .map(|s| StartingItems::from_u64(s.parse().unwrap()))
                                 .unwrap_or_default(),
-        random_starting_items: matches.value_of("random starting items")
-                                .map(|s| StartingItems::from_u64(s.parse().unwrap()))
-                                .unwrap_or_default(),
+        random_starting_items,
 
         comment: matches.value_of("text file comment").unwrap_or("").to_string(),
         main_menu_message: matches.value_of("main menu message").unwrap_or("").to_string(),

--- a/src/c_interface.rs
+++ b/src/c_interface.rs
@@ -215,9 +215,9 @@ fn inner(config_json: *const c_char, cb_data: *const (), cb: extern fn(*const ()
 
     let (pickup_layout, elevator_nums, seed) = crate::parse_layout(&config.layout_string)?;
 
-    let starting_location = SpawnRoom::from_u32(elevator_nums[0] as u32).unwrap();
+    let starting_location = SpawnRoom::from_u32(*elevator_nums.last().unwrap() as u32).unwrap();
     let mut elevator_layout = EnumMap::<Elevator, SpawnRoom>::new();
-    elevator_layout.extend(elevator_nums[1..].iter()
+    elevator_layout.extend(elevator_nums[..(elevator_nums.len() - 1)].iter()
         .zip(Elevator::iter())
         .map(|(i, elv)| (elv, SpawnRoom::from_u32(*i as u32).unwrap()))
     );
@@ -229,6 +229,9 @@ fn inner(config_json: *const c_char, cb_data: *const (), cb: extern fn(*const ()
     };
 
     let mut config = config;
+    let random_starting_items = config.random_starting_items.map(|i| i.into())
+        .unwrap_or(StartingItems::from_u64(0));
+
     let parsed_config = patches::ParsedConfig {
         input_iso, output_iso,
 
@@ -256,7 +259,7 @@ fn inner(config_json: *const c_char, cb_data: *const (), cb: extern fn(*const ()
         flaahgra_music_files,
 
         starting_items: config.starting_items.map(|i| i.into()).unwrap_or_default(),
-        random_starting_items: config.random_starting_items.map(|i| i.into()).unwrap_or_default(),
+        random_starting_items,
         comment: config.comment,
         main_menu_message: config.main_menu_message,
 

--- a/src/elevators.rs
+++ b/src/elevators.rs
@@ -517,7 +517,7 @@ impl From<ElevatorData> for SpawnRoomData
 
 decl_spawn_rooms! {
     LandingSite => {
-        pak_name: "metroid4.pak",
+        pak_name: "Metroid4.pak",
         mlvl: 0x39f2de28,
         mrea: 0xb2701146,
         mrea_idx: 0,

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -2347,12 +2347,13 @@ fn build_and_run_patches(gc_disc: &mut structs::GcDisc, config: &ParsedConfig, v
     }
     let elevator_layout = &elevator_layout;
     let spawn_room = config.starting_location;
+    
 
     let mut rng = StdRng::seed_from_u64(config.seed);
     let artifact_totem_strings = build_artifact_temple_totem_scan_strings(pickup_layout, &mut rng);
 
     let pickup_resources = collect_pickup_resources(gc_disc, &config.random_starting_items);
-    let starting_items = config.starting_items.merge(&config.random_starting_items).clone();
+    let starting_items = StartingItems::merge(config.starting_items.clone(), config.random_starting_items.clone());
 
     // XXX These values need to out live the patcher
     let select_game_fmv_suffix = ["A", "B", "C"].choose(&mut rng).unwrap();
@@ -2555,7 +2556,7 @@ fn build_and_run_patches(gc_disc: &mut structs::GcDisc, config: &ParsedConfig, v
         patch_save_banner_txtr
     );
     
-    let show_starting_items = config.random_starting_items != StartingItems::empty();
+    let show_starting_items = !config.random_starting_items.is_empty();
     patcher.add_scly_patch(
         (spawn_room.pak_name.as_bytes(), spawn_room.mrea),
         move |_ps, area| patch_starting_pickups(

--- a/src/starting_items.rs
+++ b/src/starting_items.rs
@@ -113,41 +113,60 @@ impl StartingItems
         }
     }
     
-    pub fn merge(&self, starting_items_: &StartingItems) -> StartingItems
+    pub fn merge(manual_starting_items: StartingItems, random_starting_items: StartingItems) -> Self
     {
         StartingItems {
-            scan_visor: self.scan_visor | starting_items_.scan_visor,
-            missiles: cmp::min(self.missiles + starting_items_.missiles, 250),
-            energy_tanks: cmp::min(self.energy_tanks + starting_items_.energy_tanks, 14),
-            power_bombs: cmp::min(self.power_bombs + starting_items_.power_bombs, 8),
-            wave: self.wave | starting_items_.wave,
-            ice: self.ice | starting_items_.ice,
-            plasma: self.plasma | starting_items_.plasma,
-            charge: self.charge | starting_items_.charge,
-            morph_ball: self.morph_ball | starting_items_.morph_ball,
-            bombs: self.bombs | starting_items_.bombs,
-            spider_ball: self.spider_ball | starting_items_.spider_ball,
-            boost_ball: self.boost_ball | starting_items_.boost_ball,
-            varia_suit: self.varia_suit | starting_items_.varia_suit,
-            gravity_suit: self.gravity_suit | starting_items_.gravity_suit,
-            phazon_suit: self.phazon_suit | starting_items_.phazon_suit,
-            thermal_visor: self.thermal_visor | starting_items_.thermal_visor,
-            xray: self.xray | starting_items_.xray,
-            space_jump: self.space_jump | starting_items_.space_jump,
-            grapple: self.grapple | starting_items_.grapple,
-            super_missile: self.super_missile | starting_items_.super_missile,
-            wavebuster: self.wavebuster | starting_items_.wavebuster,
-            ice_spreader: self.ice_spreader | starting_items_.ice_spreader,
-            flamethrower: self.flamethrower | starting_items_.flamethrower,
+            scan_visor: manual_starting_items.scan_visor | random_starting_items.scan_visor,
+            missiles: cmp::min(manual_starting_items.missiles + random_starting_items.missiles, 250),
+            energy_tanks: cmp::min(manual_starting_items.energy_tanks + random_starting_items.energy_tanks, 14),
+            power_bombs: cmp::min(manual_starting_items.power_bombs + random_starting_items.power_bombs, 8),
+            wave: manual_starting_items.wave | random_starting_items.wave,
+            ice: manual_starting_items.ice | random_starting_items.ice,
+            plasma: manual_starting_items.plasma | random_starting_items.plasma,
+            charge: manual_starting_items.charge | random_starting_items.charge,
+            morph_ball: manual_starting_items.morph_ball | random_starting_items.morph_ball,
+            bombs: manual_starting_items.bombs | random_starting_items.bombs,
+            spider_ball: manual_starting_items.spider_ball | random_starting_items.spider_ball,
+            boost_ball: manual_starting_items.boost_ball | random_starting_items.boost_ball,
+            varia_suit: manual_starting_items.varia_suit | random_starting_items.varia_suit,
+            gravity_suit: manual_starting_items.gravity_suit | random_starting_items.gravity_suit,
+            phazon_suit: manual_starting_items.phazon_suit | random_starting_items.phazon_suit,
+            thermal_visor: manual_starting_items.thermal_visor | random_starting_items.thermal_visor,
+            xray: manual_starting_items.xray | random_starting_items.xray,
+            space_jump: manual_starting_items.space_jump | random_starting_items.space_jump,
+            grapple: manual_starting_items.grapple | random_starting_items.grapple,
+            super_missile: manual_starting_items.super_missile | random_starting_items.super_missile,
+            wavebuster: manual_starting_items.wavebuster | random_starting_items.wavebuster,
+            ice_spreader: manual_starting_items.ice_spreader | random_starting_items.ice_spreader,
+            flamethrower: manual_starting_items.flamethrower | random_starting_items.flamethrower,
         }
     }
     
-    pub fn empty() -> Self
+    pub fn is_empty(&self) -> bool
     {
-        let mut _starting_items = StartingItems::default();
-        _starting_items.scan_visor = false;
-        
-        _starting_items
+        !self.scan_visor &&
+        self.missiles == 0 &&
+        self.energy_tanks == 0 &&
+        self.power_bombs == 0 &&
+        !self.wave &&
+        !self.ice &&
+        !self.plasma &&
+        !self.charge &&
+        !self.morph_ball &&
+        !self.bombs &&
+        !self.spider_ball &&
+        !self.boost_ball &&
+        !self.varia_suit &&
+        !self.gravity_suit &&
+        !self.phazon_suit &&
+        !self.thermal_visor &&
+        !self.xray &&
+        !self.space_jump &&
+        !self.grapple &&
+        !self.super_missile &&
+        !self.wavebuster &&
+        !self.ice_spreader &&
+        !self.flamethrower
     }
 }
 


### PR DESCRIPTION
Some pak names were in lower case
The spawn room shouldn't check first but last elevator instead for backward compatibility
Not referencing random starting items would cause the random starting items to default to vanilla starting items
Changed a.merge(b) to StartingItems::merge(a, b)
Removed StartingItems::empty()
Added StartingItems_instance.is_empty()