### PR TITLE
Add option for making the crash screen appear automatically

### DIFF
--- a/generated/dol_symbol_table/1.00.txt
+++ b/generated/dol_symbol_table/1.00.txt
@@ -14337,3 +14337,4 @@
 0x805a8c34 g_MainStringTable
 0x805a8c40 g_GameState
 0x805aa82c g_EtankCapacity
+0x802d6a44 CrashScreenControllerPollBranch

--- a/generated/dol_symbol_table/1.02.txt
+++ b/generated/dol_symbol_table/1.02.txt
@@ -6995,3 +6995,4 @@
 0x805a9cd4 g_MainStringTable
 0x805a9ce0 g_GameState
 0x805ab8ec g_EtankCapacity
+0x802d7494 CrashScreenControllerPollBranch

--- a/generated/dol_symbol_table/pal.txt
+++ b/generated/dol_symbol_table/pal.txt
@@ -2762,3 +2762,4 @@
 0x8046ad38 g_MainStringTable
 0x8046ad44 g_GameState
 0x8046c99c g_EtankCapacity
+0x802c2558 CrashScreenControllerPollBranch

--- a/src/patch_config.rs
+++ b/src/patch_config.rs
@@ -138,6 +138,7 @@ pub struct PatchConfig
     pub skip_hudmenus: bool,
     pub keep_fmvs: bool,
     pub obfuscate_items: bool,
+    pub automatic_crash_screen: bool,
     pub etank_capacity: u32,
     pub nonvaria_heat_damage: bool,
     pub heat_damage_per_sec: f32,
@@ -215,6 +216,7 @@ struct Preferences
     obfuscate_items: Option<bool>,
     map_default_state: Option<String>,
     artifact_hint_behavior: Option<String>,
+    automatic_crash_screen: Option<bool>,
     trilogy_disc_path: Option<String>,
     keep_fmvs: Option<bool>,
     quickplay: Option<bool>,
@@ -308,6 +310,9 @@ impl PatchConfig
             .arg(Arg::with_name("skip hudmenus")
                 .long("non-modal-item-messages")
                 .help("Display a non-modal message when an item is is acquired"))
+            .arg(Arg::with_name("automatic crash screen")
+                .long("automatic-crash-screen")
+                .help("Makes the crash screen appear without any button combination required"))
             .arg(Arg::with_name("etank capacity")
                 .long("etank-capacity")
                 .help("Set the etank capacity and base health")
@@ -411,6 +416,7 @@ impl PatchConfig
         populate_config_bool!(matches;
             "skip hudmenus" => patch_config.preferences.skip_hudmenus,
             "obfuscate items" => patch_config.preferences.obfuscate_items,
+            "automatic crash screen" => patch_config.preferences.automatic_crash_screen,
             "keep attract mode" => patch_config.preferences.keep_fmvs,
             "quickplay" => patch_config.preferences.quickplay,
             "quiet" => patch_config.preferences.quiet,
@@ -560,6 +566,7 @@ impl PatchConfigPrivate
 
             skip_hudmenus: self.preferences.skip_hudmenus.unwrap_or(true),
             obfuscate_items: self.preferences.obfuscate_items.unwrap_or(false),
+            automatic_crash_screen: self.preferences.automatic_crash_screen.unwrap_or(false),
             artifact_hint_behavior,
             flaahgra_music_files,
             keep_fmvs: self.preferences.keep_fmvs.unwrap_or(false),

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -2314,6 +2314,13 @@ fn patch_dol<'r>(
     // });
     // dol_patcher.ppcasm_patch(&ball_color_patch)?;
 
+    if config.automatic_crash_screen {
+        let automatic_crash_patch = ppcasm!(symbol_addr!("CrashScreenControllerPollBranch", version), {
+            nop;
+        });
+        dol_patcher.ppcasm_patch(&automatic_crash_patch)?;
+    }
+
     let cinematic_skip_patch = ppcasm!(symbol_addr!("ShouldSkipCinematic__22CScriptSpecialFunctionFR13CStateManager", version), {
             li      r3, 0x1;
             blr;


### PR DESCRIPTION
This makes the crash screen appear instantly, instead of requiring the user to input the button combination (controller 2, hold X+Y+Z, then press in order Right, Left, Down and Up in the D-Pad).

![image](https://user-images.githubusercontent.com/884928/127737406-73aab767-9642-41e3-8737-0eb07b795a42.png)
